### PR TITLE
Use ${HOME}, create vendor dir if doesn't exist

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,10 +13,9 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 EXPORT_PATH="$PWD/export"
 PROFILE_PATH="$BUILD_DIR/.profile.d/gsl.sh"
 
-echo "VENDOR_DIR $VENDOR_DIR"
-
 mkdir -p $(dirname $PROFILE_PATH)
 mkdir -p $VENDOR_DIR
+mkdir -p "${HOME}/vendor"
 
 function set-default-env (){
   echo "export $1=\$$1:${HOME}/vendor/$2" >> $PROFILE_PATH
@@ -29,7 +28,6 @@ mv "$VENDOR_DIR/gsl-1.16" "$VENDOR_DIR/gsl"
 # FYI we do this and set the export path explicitly because we cannot assume all buildpacks copy this dir over
 # We need to also leave the vendor dir repo in place, as the current app vendor gets blown away and replaced with
 # what is in the build dir
-[ -d "${HOME}/vendor" ] && echo "Directory ${HOME}/vendor exists."
 cp -R "$VENDOR_DIR/gsl" "${HOME}/vendor/gsl"
 
 set-default-env PATH "gsl/bin"

--- a/bin/compile
+++ b/bin/compile
@@ -19,8 +19,8 @@ mkdir -p $(dirname $PROFILE_PATH)
 mkdir -p $VENDOR_DIR
 
 function set-default-env (){
-  echo "export $1=\$$1:/app/vendor/$2" >> $PROFILE_PATH
-  echo "export $1=\$$1:/app/vendor/$2" >> $EXPORT_PATH
+  echo "export $1=\$$1:${HOME}/vendor/$2" >> $PROFILE_PATH
+  echo "export $1=\$$1:${HOME}/vendor/$2" >> $EXPORT_PATH
 }
 
 echo "-----> Fetching and vendoring gsl"
@@ -29,8 +29,8 @@ mv "$VENDOR_DIR/gsl-1.16" "$VENDOR_DIR/gsl"
 # FYI we do this and set the export path explicitly because we cannot assume all buildpacks copy this dir over
 # We need to also leave the vendor dir repo in place, as the current app vendor gets blown away and replaced with
 # what is in the build dir
-[ -d "/app/vendor/gsl" ] && echo "Directory /app/vendor/gsl exists."
-cp -R "$VENDOR_DIR/gsl" "/app/vendor/gsl"
+[ -d "${HOME}/vendor" ] && echo "Directory ${HOME}/vendor exists."
+cp -R "$VENDOR_DIR/gsl" "${HOME}/vendor/gsl"
 
 set-default-env PATH "gsl/bin"
 set-default-env LD_LIBRARY_PATH "gsl/lib"

--- a/bin/compile
+++ b/bin/compile
@@ -5,13 +5,15 @@
 set -e
 
 # Debug
-# set -x
+set -x
 
 BUILD_DIR=$1
 CACHE_DIR=$2
 VENDOR_DIR="$BUILD_DIR/vendor"
 EXPORT_PATH="$PWD/export"
 PROFILE_PATH="$BUILD_DIR/.profile.d/gsl.sh"
+
+echo "VENDOR_DIR $VENDOR_DIR"
 
 mkdir -p $(dirname $PROFILE_PATH)
 mkdir -p $VENDOR_DIR
@@ -27,6 +29,7 @@ mv "$VENDOR_DIR/gsl-1.16" "$VENDOR_DIR/gsl"
 # FYI we do this and set the export path explicitly because we cannot assume all buildpacks copy this dir over
 # We need to also leave the vendor dir repo in place, as the current app vendor gets blown away and replaced with
 # what is in the build dir
+[ -d "/app/vendor/gsl" ] && echo "Directory /app/vendor/gsl exists."
 cp -R "$VENDOR_DIR/gsl" "/app/vendor/gsl"
 
 set-default-env PATH "gsl/bin"

--- a/bin/compile
+++ b/bin/compile
@@ -5,7 +5,7 @@
 set -e
 
 # Debug
-set -x
+# set -x
 
 BUILD_DIR=$1
 CACHE_DIR=$2

--- a/bin/compile
+++ b/bin/compile
@@ -5,30 +5,28 @@
 set -e
 
 # Debug
-# set -x
+set -x
 
 BUILD_DIR=$1
 CACHE_DIR=$2
-VENDOR_DIR="$BUILD_DIR/vendor"
+GSL_BUILD_DIR="${BUILD_DIR}/vendor/gsl"
+APP_VENDOR_DIR="${HOME}/vendor"
 EXPORT_PATH="$PWD/export"
-PROFILE_PATH="$BUILD_DIR/.profile.d/gsl.sh"
+PROFILE_PATH="${BUILD_DIR}/.profile.d/gsl.sh"
 
 mkdir -p $(dirname $PROFILE_PATH)
-mkdir -p $VENDOR_DIR
-mkdir -p "${HOME}/vendor"
+mkdir -p $GSL_BUILD_DIR
+mkdir -p $APP_VENDOR_DIR
 
 function set-default-env (){
-  echo "export $1=\$$1:${HOME}/vendor/$2" >> $PROFILE_PATH
-  echo "export $1=\$$1:${HOME}/vendor/$2" >> $EXPORT_PATH
+  echo "export $1=\$$1:${APP_VENDOR_DIR}/$2" >> $PROFILE_PATH
+  echo "export $1=\$$1:${APP_VENDOR_DIR}/$2" >> $EXPORT_PATH
 }
 
 echo "-----> Fetching and vendoring gsl"
-curl "https://s3.amazonaws.com/opendoor-deps/gsl-1.16.tar.gz" -s -o - | tar xzf - -C "$VENDOR_DIR"
-mv "$VENDOR_DIR/gsl-1.16" "$VENDOR_DIR/gsl"
+curl "https://s3.amazonaws.com/opendoor-deps/gsl-1.16.tar.gz" -s -o - | tar xzf - --strip 1 -C "$GSL_BUILD_DIR"
 # FYI we do this and set the export path explicitly because we cannot assume all buildpacks copy this dir over
-# We need to also leave the vendor dir repo in place, as the current app vendor gets blown away and replaced with
-# what is in the build dir
-cp -R "$VENDOR_DIR/gsl" "${HOME}/vendor/gsl"
+cp -R "$GSL_BUILD_DIR" "${APP_VENDOR_DIR}/gsl"
 
 set-default-env PATH "gsl/bin"
 set-default-env LD_LIBRARY_PATH "gsl/lib"


### PR DESCRIPTION
`${HOME}` is /app (for now), but seemed like best practice from other buildpacks I looked at